### PR TITLE
Nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ node_modules/
 
 ## Directory-based project format:
 .idea/
+
+## VSCode
+.vscode/

--- a/lib/index.js
+++ b/lib/index.js
@@ -385,7 +385,7 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
       if (parameterDefinition.in === 'body') {
         return validateSchema(parameterDefinition.name, parameterDefinition.type, parameterDefinition.format, parameterDefinition.schema, parameterValue);
       } else {
-        return validateValue(parameterDefinition.name, parameterDefinition.type, parameterDefinition.format, undefined, parameterDefinition.items, undefined, undefined, parameterValue);
+        return validateValue(parameterDefinition.name, parameterDefinition.type, parameterDefinition.format, parameterDefinition['x-nullable'], parameterDefinition.items, undefined, undefined, parameterValue);
       }
     } catch (err) {
       throw new ParameterValidationError(parameterDefinition, parameterValue, err);


### PR DESCRIPTION
Since `formData` is also used for regular (read application/json) calls, we also need to allow `null` to be passed and allowed.