### PR TITLE
[Fix] Allow custom error codes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -441,8 +441,8 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
       yield next;
     } catch (err) {
       debug(err);
-
-      this.status = HTTPStatus.BAD_REQUEST;
+      // Temporary : koa-spec should probably not be the global error handler
+      this.status = err.statusCode || HTTPStatus.BAD_REQUEST;
       this.body = {
         code      : err.code,
         message   : err.message,


### PR DESCRIPTION
Whenever an error is thrown in a controller, koa-spec currently forces a BAD_REQUEST status code while the error might not be a validation one. The change in this PR is meant to be temporary waiting for a more resilient way of handling errors, probably outside of koa-spec.
