### PR TITLE
String encoded array parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ $ curl localhost:8000 ⏎
 - [x] Routing
 - [x] Validation
   - [x] Required
+  - [x] Default values
+    - [x] Body parameter
+    - [x] Query string
+    - [ ] Headers
   - [x] x-nullable
   - [ ] Parameter
     - [ ] Sources

--- a/examples/simple/app.js
+++ b/examples/simple/app.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/*
+ * This the most simple example of using koa-spec for a simple index page.
+ */
+
 const path = require('path');
 const koa = require('koa');
 const koaspec = require('../..'); // 'koa-spec'

--- a/lib/index.js
+++ b/lib/index.js
@@ -275,8 +275,13 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
 
   function validateArray(name, type, format, items, values) {
     if (!_.isArray(values)) {
-      const stringEncodedValues = JSON.parse(values);
-      if (_.isArray(stringEncodedValues)) {
+      let stringEncodedValues = null;
+      try {
+        stringEncodedValues = JSON.parse(values);
+      } catch (err) {
+        throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);
+      }
+      if (stringEncodedValues && _.isArray(stringEncodedValues)) {
         values = stringEncodedValues;
       } else {
         throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ function createRouter(spec, options) {
   }
 
   function createNotImplementedControllerMethod(method, route) {
-    return function* (next) {
+    return function*(next) {
       this.status = HTTPStatus.NOT_IMPLEMENTED;
       const err = new RouteNotImplementedError(method, route);
       this.body = {
@@ -329,7 +329,7 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
   }
 
   function validateValue(name, type, format, nullable, items, properties, required, value) {
-    if (_.isNull(value)){
+    if (_.isNull(value)) {
       if (!_.isUndefined(nullable)) {
         if (nullable) {
           return null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,12 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
 
   function validateArray(name, type, format, items, values) {
     if (!_.isArray(values)) {
-      throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);
+      const stringEncodedValues = JSON.parse(values);
+      if (_.isArray(stringEncodedValues)) {
+        values = stringEncodedValues;
+      } else {
+        throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);
+      }
     }
     if (!items) {
       throw new TypeValidationError(name, type, format, values, `Items not found.`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -304,7 +304,8 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
         propertyInfo = _.get(spec.resolved, utils.pathFromPtr(ref.uri).join('.'));
       }
 
-      const propertyValue = value[propertyName];
+      let propertyValue = value[propertyName];
+
       /* Check for required properties: */
       if (_.includes(required, propertyName)) {
         if (_.isUndefined(propertyValue)) {
@@ -312,13 +313,18 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
         }
       } else {
         if (_.isUndefined(propertyValue)) {
-          return;
+          /* Apply default value if defined */
+          if (!_.isUndefined(propertyInfo.default)) {
+            propertyValue = propertyInfo.default;
+          }
+          else return;
         }
       }
 
       const validatedPropertyValue = validateValue(propertyName, propertyInfo.type, propertyInfo.format, propertyInfo['x-nullable'], propertyInfo.items, propertyInfo.properties, propertyInfo.required, propertyValue);
       actualValue[propertyName] = validatedPropertyValue;
     });
+    
     return actualValue;
   }
 
@@ -378,7 +384,10 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
         }
       } else {
         if (_.isUndefined(parameterValue)) {
-          return parameterValue;
+          if (!_.isUndefined(parameterDefinition.default)) {
+            parameterValue = parameterDefinition.default;
+          }
+          else return parameterValue;
         }
       }
 

--- a/test/controllers/BookController.js
+++ b/test/controllers/BookController.js
@@ -9,11 +9,15 @@ module.exports.getByQueryISBN = function* () {
 
 module.exports.createFromBody = function* () {
   const body = this.request.body; // TODO Want this to be just "body" not "request.body" ?
+
   this.body = {
-    id        : 1,
-    isbn      : body.isbn,
-    authors   : body.authors,
-    publisher : body.publisher
+    id              : 1,
+    isbn            : body.isbn,
+    format          : body.format,
+    authors         : body.authors,
+    publisher       : body.publisher,
+    isFavorite      : body.isFavorite,
+    availableSince  : body.availableSince
   };
 };
 
@@ -33,4 +37,8 @@ module.exports.createFromBodyArray = function* () {
       publisher : body.publisher
     }
   ];
+};
+
+module.exports.get = function* () {
+  this.body = Object.assign({ id: 1 }, this.request.query);
 };

--- a/test/data/body_parameter_defaults.yaml
+++ b/test/data/body_parameter_defaults.yaml
@@ -1,0 +1,71 @@
+swagger: '2.0'
+info:
+  version: 0.0.1
+  title: Body parameter with default.
+paths:
+  /books:
+    post:
+      x-controller: BookController
+      x-controller-method: createFromBody
+      parameters:
+        - $ref: '#/parameters/Book'
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/Book'
+parameters:
+  Book:
+    name: book
+    description: 'Book with default value.'
+    in: body
+    required: true
+    schema:
+      $ref: '#/definitions/BookBlueprint'
+definitions:
+  BookBlueprint:
+    title: BookBlueprint
+    type: object
+    properties:
+      format:
+        type: string
+        example: 'EBook'
+        default: 'PocketBook'
+        enum:
+          - 'EBook'
+          - 'AudioBook'
+          - 'PocketBook'
+      isFavorite:
+        type: boolean
+        default: false
+      availableSince:
+        type: string
+        format: date-time
+        default: '2016-06-08T16:59:29.681Z'  
+      isbn:
+        type: string
+        format: isbn
+        example: '978-3-16-148410-0'
+  Book:
+    title: Book
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE'
+      format: 
+        type: string
+        enum:
+          - 'EBook'
+          - 'AudioBook'
+          - 'PocketBook'
+      availableSince:
+        type: string
+        format: date-time
+      isFavorite:
+        type: boolean
+      isbn:
+        type: string
+        format: isbn
+        example: '978-1-84951-899-4'

--- a/test/data/query_parameter_defaults.yaml
+++ b/test/data/query_parameter_defaults.yaml
@@ -1,0 +1,55 @@
+swagger: '2.0'
+info:
+  version: 0.0.1
+  title: Query parameter with default.
+paths:
+  /books:
+    get:
+      x-controller: BookController
+      x-controller-method: get
+      parameters:
+        availability:
+          name: availability
+          type: string
+          default: 'in_stock'
+          in: query
+          enum:
+            - 'in_stock'
+            - 'out_of_stock'
+            - 'available_soon'
+        isAvailable:
+          name: isAvailable
+          type: boolean
+          default: true
+          in: query
+        availableSince:
+          name: availableSince
+          type: string
+          format: date-time
+          default: '2016-06-08T17:07:43.631Z'
+          in: query
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/Book'
+definitions:
+  Book:
+    title: Book
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        example: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE'
+      isAvailable:
+        type: boolean
+      availableSince:
+        type: string
+        format: date-time
+      availability:
+        type: string
+        enum:
+          - 'in_stock'
+          - 'out_of_stock'
+          - 'available_soon'

--- a/test/test.js
+++ b/test/test.js
@@ -481,6 +481,63 @@ describe('koaspec', function () {
           };
           expect(actual).to.containSubset(expected);
         });
+
+        describe('supports default values', function () {
+          
+          it('should apply default value', function* () {
+            const app = koa();
+
+            const spec = koaspec('test/data/query_parameter_defaults.yaml', OPTIONS_TEST);
+
+            const router = spec.router();
+            app.use(router.routes());
+
+            const res = yield supertest(http.createServer(app.callback()))
+              .get('/books')
+              .query({
+                id : 1
+              })
+              .expect(HTTPStatus.OK);
+
+            const actual = res.body;
+            const expected = {
+              id              : '1',
+              availability    : 'in_stock',
+              isAvailable     : true,
+              availableSince  : '2016-06-08T17:07:43.631Z'
+            };
+            expect(actual).to.containSubset(expected);
+          });
+
+          it('should NOT apply default value', function* () {
+            const app = koa();
+
+            const spec = koaspec('test/data/query_parameter_defaults.yaml', OPTIONS_TEST);
+
+            const router = spec.router();
+            app.use(router.routes());
+
+            const res = yield supertest(http.createServer(app.callback()))
+              .get('/books')
+              .query({
+                id	            : 1,
+                availability    : 'out_of_stock',
+                isAvailable     : false,
+                availableSince  : new Date('2016-06-08T17:15:14.731Z')
+              })
+              .expect(HTTPStatus.OK);
+
+            const actual = res.body;
+            const expected = {
+              id              : '1',
+              availability    : 'out_of_stock',
+              availableSince  : '2016-06-08T17:15:14.731Z'
+            };
+            expect(actual).to.containSubset(expected);
+          });
+
+        });
+
       });
 
       describe('body', function () {
@@ -800,6 +857,74 @@ describe('koaspec', function () {
           };
           expect(actual).to.containSubset(expected);
         });
+
+        describe('supports default values', function () {
+          it('should apply default value', function* () {
+            const bodyParser = require('koa-bodyparser');
+            const app = koa();
+
+            app.use(bodyParser());
+
+            const spec = koaspec('test/data/body_parameter_defaults.yaml', OPTIONS_TEST);
+
+            const router = spec.router();
+            app.use(router.routes());
+
+            const res = yield supertest(http.createServer(app.callback()))
+              .post('/books')
+              .send({
+                isbn    : '978-1-84951-899-4'
+              })
+              .expect(HTTPStatus.OK);
+
+            const actual = res.body;
+
+            const expected = {
+              id              : 1,
+              isbn            : '978-1-84951-899-4',
+              format          : 'PocketBook',
+              isFavorite      : false,
+              availableSince  : '2016-06-08T16:59:29.681Z'      
+            };
+
+            expect(actual).to.containSubset(expected);
+          });
+
+          it('should NOT apply default value', function* () {
+            const bodyParser = require('koa-bodyparser');
+            const app = koa();
+
+            app.use(bodyParser());
+
+            const spec = koaspec('test/data/body_parameter_defaults.yaml', OPTIONS_TEST);
+
+            const router = spec.router();
+            app.use(router.routes());
+
+            const res = yield supertest(http.createServer(app.callback()))
+              .post('/books')
+              .send({
+                isbn            : '978-1-84951-899-4',
+                format          : 'EBook',
+                isFavorite      : true,
+                availableSince  : new Date('2016-06-08T17:07:43.631Z')
+              })
+              .expect(HTTPStatus.OK);
+
+            const actual = res.body;
+
+            const expected = {
+              id              : 1,
+              isbn            : '978-1-84951-899-4',
+              format          : 'EBook',
+              isFavorite      : true,
+              availableSince  : '2016-06-08T17:07:43.631Z'
+            };
+
+            expect(actual).to.containSubset(expected);
+          });
+        });
+        
       });
 
       describe('formData', function () {
@@ -1617,9 +1742,9 @@ describe('koaspec', function () {
         expect(actual).to.eql(false);
       });
 
-      it('parses a "false" string value.', function* () {
-        const actual = utils.parseBoolean('false');
-        expect(actual).to.eql(false);
+      it('parses a "true" string value.', function* () {
+        const actual = utils.parseBoolean('true');
+        expect(actual).to.eql(true);
       });
 
       it('parses a "false" string value.', function* () {

--- a/test/test.js
+++ b/test/test.js
@@ -858,6 +858,66 @@ describe('koaspec', function () {
           expect(actual).to.containSubset(expected);
         });
 
+        it('supports arrays with primitive (non-object) items that are string encoded.', function* () {
+          const bodyParser = require('koa-bodyparser');
+          const app = koa();
+
+          app.use(bodyParser());
+
+          const spec = koaspec('test/data/body_parameter_object_nested_array_string.yaml', OPTIONS_TEST);
+
+          const router = spec.router();
+          app.use(router.routes());
+
+          const res = yield supertest(http.createServer(app.callback()))
+            .post('/books')
+            .send({
+              isbn    : '978-1-84951-899-4',
+              authors : JSON.stringify(['Jayme, Schroeder', 'Brian Boyles'])
+            })
+            .expect(HTTPStatus.OK);
+
+          const actual = res.body;
+
+          const expected = {
+            id        : 1,
+            isbn      : '978-1-84951-899-4',
+            authors : [
+              'Jayme, Schroeder',
+              'Brian Boyles'
+            ]
+          };
+          expect(actual).to.containSubset(expected);
+        });
+
+        it('detects arrays with primitive (non-object) items that are improperly string encoded.', function* () {
+          const bodyParser = require('koa-bodyparser');
+          const app = koa();
+
+          app.use(bodyParser());
+
+          const spec = koaspec('test/data/body_parameter_object_nested_array_string.yaml', OPTIONS_TEST);
+
+          const router = spec.router();
+          app.use(router.routes());
+
+          const res = yield supertest(http.createServer(app.callback()))
+            .post('/books')
+            .send({
+              isbn    : '978-1-84951-899-4',
+              authors : JSON.stringify({
+                'Jayme' : 'Schroeder'
+              })
+            })
+            .expect(HTTPStatus.BAD_REQUEST);
+
+          const actual = res.body;
+          const expected = {
+            code : ERROR_CODES.VALIDATION_TYPE
+          };
+          expect(actual).to.containSubset(expected);
+        });
+
         describe('supports default values', function () {
           it('should apply default value', function* () {
             const bodyParser = require('koa-bodyparser');


### PR DESCRIPTION
Allows i.e. for query parameters that are formatted like: 
`something_ids[1,2,3,4]`
instead of much more verbose:
`something_ids[]=1&something_ids[]=2something_ids[]=3something_ids[]=4`
