### PR TITLE
String encoded array parameters. 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -275,8 +275,13 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
 
   function validateArray(name, type, format, items, values) {
     if (!_.isArray(values)) {
-      const stringEncodedValues = JSON.parse(values);
-      if (_.isArray(stringEncodedValues)) {
+      let stringEncodedValues = null;
+      try {
+        stringEncodedValues = JSON.parse(values);
+      } catch (err) {
+        throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);
+      }
+      if (stringEncodedValues && _.isArray(stringEncodedValues)) {
         values = stringEncodedValues;
       } else {
         throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -275,7 +275,12 @@ function createRequestValidator(spec, method, route, parameterDefinitions) {
 
   function validateArray(name, type, format, items, values) {
     if (!_.isArray(values)) {
-      throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);
+      const stringEncodedValues = JSON.parse(values);
+      if (_.isArray(stringEncodedValues)) {
+        values = stringEncodedValues;
+      } else {
+        throw new TypeValidationError(name, type, format, values, `Not an 'array'.`);
+      }
     }
     if (!items) {
       throw new TypeValidationError(name, type, format, values, `Items not found.`);

--- a/test/test.js
+++ b/test/test.js
@@ -858,6 +858,66 @@ describe('koaspec', function () {
           expect(actual).to.containSubset(expected);
         });
 
+        it('supports arrays with primitive (non-object) items that are string encoded.', function* () {
+          const bodyParser = require('koa-bodyparser');
+          const app = koa();
+
+          app.use(bodyParser());
+
+          const spec = koaspec('test/data/body_parameter_object_nested_array_string.yaml', OPTIONS_TEST);
+
+          const router = spec.router();
+          app.use(router.routes());
+
+          const res = yield supertest(http.createServer(app.callback()))
+            .post('/books')
+            .send({
+              isbn    : '978-1-84951-899-4',
+              authors : JSON.stringify(['Jayme, Schroeder', 'Brian Boyles'])
+            })
+            .expect(HTTPStatus.OK);
+
+          const actual = res.body;
+
+          const expected = {
+            id        : 1,
+            isbn      : '978-1-84951-899-4',
+            authors : [
+              'Jayme, Schroeder',
+              'Brian Boyles'
+            ]
+          };
+          expect(actual).to.containSubset(expected);
+        });
+
+        it('detects arrays with primitive (non-object) items that are improperly string encoded.', function* () {
+          const bodyParser = require('koa-bodyparser');
+          const app = koa();
+
+          app.use(bodyParser());
+
+          const spec = koaspec('test/data/body_parameter_object_nested_array_string.yaml', OPTIONS_TEST);
+
+          const router = spec.router();
+          app.use(router.routes());
+
+          const res = yield supertest(http.createServer(app.callback()))
+            .post('/books')
+            .send({
+              isbn    : '978-1-84951-899-4',
+              authors : JSON.stringify({
+                'Jayme' : 'Schroeder'
+              })
+            })
+            .expect(HTTPStatus.BAD_REQUEST);
+
+          const actual = res.body;
+          const expected = {
+            code : ERROR_CODES.VALIDATION_TYPE
+          };
+          expect(actual).to.containSubset(expected);
+        });
+
         describe('supports default values', function () {
           it('should apply default value', function* () {
             const bodyParser = require('koa-bodyparser');


### PR DESCRIPTION
Allows i.e. for query parameters that are formatted like: 
`something_ids[1,2,3,4]`
instead of much more verbose:
`something_ids[]=1&something_ids[]=2something_ids[]=3something_ids[]=4`
